### PR TITLE
Fix #22 by improving the error when reaching to 20 channel limitation of an event trigger

### DIFF
--- a/functions/configure.ts
+++ b/functions/configure.ts
@@ -102,7 +102,9 @@ export default SlackFunction(def, async ({ inputs, client, env }) => {
         }
       } catch (e) {
         console.log(e);
-        modalMessage = e;
+        modalMessage =
+          "*:warning: Apologies! Failed to configure this app due to the following error:*\n>" +
+          e;
       }
       // nothing to return if you want to close this modal
       return buildModalUpdateResponse(modalMessage);

--- a/functions/internals/trigger_operations.ts
+++ b/functions/internals/trigger_operations.ts
@@ -122,7 +122,7 @@ async function joinChannel(
       console.log(`auth.test API result: ${JSON.stringify(authTest)}`);
     }
     const error =
-      `:warning: Failed to join <#${channelId}> due to "${response.error}" error. This workflow is unable to add <@${authTest.user_id}> to private channels and DMs. For those conversations, please invite the bot user in advance :bow:`;
+      `*:warning: Failed to join <#${channelId}> due to "${response.error}" error!*\n\nThis workflow is unable to add <@${authTest.user_id}> to private channels and DMs. For those conversations, please invite the bot user in advance :bow:`;
     console.log(error);
     return error;
   }


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This pull request resolves #22 by fixing the UI error when displaying an error on a modal

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
