### PR TITLE
Add the option to choose emojis to make the workflow even more const-efficient

### DIFF
--- a/functions/configure.ts
+++ b/functions/configure.ts
@@ -159,6 +159,7 @@ function buildModalView(conversationIds: string[], reactions: string[]) {
     "block_id": "block2",
     "element": {
       "type": "multi_static_select",
+      "max_selected_items": 9,
       "placeholder": {
         "type": "plain_text",
         // An event trigger's filter object can accept only 18 statements.

--- a/functions/detect_lang.ts
+++ b/functions/detect_lang.ts
@@ -30,17 +30,17 @@ export default SlackFunction(def, ({
     const matched = reactionName.match(/(?!flag-\b)\b\w+/);
     if (matched != null) {
       const country = matched[0];
-      lang = reactionToLang[country];
+      lang = allReactionToLang[country];
     }
   } else {
     // jp, fr, etc.
-    lang = reactionToLang[reactionName];
+    lang = allReactionToLang[reactionName];
   }
   return { outputs: { lang } };
 });
 
 // data mapping between reaction names and language codes
-export const reactionToLang: Record<string, string> = {
+export const allReactionToLang: Record<string, string> = {
   ac: "en",
   ag: "en",
   ai: "en",
@@ -117,6 +117,7 @@ export const reactionToLang: Record<string, string> = {
   jp: "ja",
   ke: "en",
   ki: "en",
+  kr: "ko",
   kn: "en",
   ky: "en",
   lc: "en",
@@ -197,4 +198,28 @@ export const reactionToLang: Record<string, string> = {
   se: "sv",
   tr: "tr",
   ua: "uk",
+};
+
+// TODO: add more emojis to this list
+export const upTo100ReactionToLang: Record<string, string> = {
+  cn: "zh",
+  de: "de",
+  es: "es",
+  fr: "fr",
+  gb: "en",
+  it: "it",
+  jp: "ja",
+  kr: "ko",
+  pl: "pl",
+  pt: "pt",
+  ru: "ru",
+  us: "en",
+  bg: "bg",
+  fi: "fi",
+  hu: "hu",
+  id: "id",
+  lt: "lt",
+  ro: "ro",
+  sk: "sk",
+  tr: "tr",
 };


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [x] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This pull request improves the cost-efficiency of this app. Currently, this app's workflow can be invoked whenever a user adds _any_ reaction in the channels where the workflow is set. This can be quite cost-inefficient especially for large organizations and their busy channels.

With the changes in this PR, the app admin users can filter the trigger events to a few specific reactions. This filtering in the event trigger can significantly reduce the cost of running this workflow.

<img width="506" src="https://github.com/slack-samples/deno-message-translator/assets/19658/89b54e6e-c14d-4829-bd11-44a2d0719bd4">

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
