### PR TITLE
chore: update Deno imports to use JSR

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,8 +30,9 @@
     "test": "deno fmt --check && deno lint && deno test --allow-read"
   },
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/",
+    "@slack/api": "jsr:@slack/api@2.9.0",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+
     "@std/testing": "jsr:@std/testing@^1.0.16",
     "@std/assert": "jsr:@std/assert@^1.0.15"
   }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -31,7 +31,7 @@
   },
   "imports": {
     "@slack/api": "jsr:@slack/api@2.9.0",
-    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2",
 
     "@std/testing": "jsr:@std/testing@^1.0.16",
     "@std/assert": "jsr:@std/assert@^1.0.15"

--- a/functions/detect_lang.ts
+++ b/functions/detect_lang.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema, SlackFunction } from "@slack/sdk";
 import { isDebugMode } from "./internals/debug_mode.ts";
 
 export const def = DefineFunction({

--- a/functions/detect_lang_test.ts
+++ b/functions/detect_lang_test.ts
@@ -1,4 +1,4 @@
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import { assertEquals } from "@std/assert";
 import handler from "./detect_lang.ts";
 

--- a/functions/translate.ts
+++ b/functions/translate.ts
@@ -1,5 +1,5 @@
-import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
-import type { SlackAPIClient } from "deno-slack-sdk/types.ts";
+import { DefineFunction, Schema, SlackFunction } from "@slack/sdk";
+import type { SlackAPIClient } from "@slack/sdk/types.ts";
 import { isDebugMode } from "./internals/debug_mode.ts";
 
 export const def = DefineFunction({

--- a/functions/translate_test.ts
+++ b/functions/translate_test.ts
@@ -1,4 +1,4 @@
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import { assertEquals } from "@std/assert";
 import { stub } from "@std/testing/mock";
 import handler from "./translate.ts";

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "deno-slack-sdk/mod.ts";
+import { Manifest } from "@slack/sdk";
 import { def as detectLang } from "./functions/detect_lang.ts";
 import { def as translate } from "./functions/translate.ts";
 import reacjilator from "./workflows/reacjilator.ts";

--- a/triggers/reaction_added_trigger.ts
+++ b/triggers/reaction_added_trigger.ts
@@ -1,9 +1,9 @@
-import type { Trigger } from "deno-slack-sdk/types.ts";
+import type { Trigger } from "@slack/sdk/types.ts";
 import {
   TriggerContextData,
   TriggerEventTypes,
   TriggerTypes,
-} from "deno-slack-api/mod.ts";
+} from "@slack/api";
 import workflowDef from "../workflows/reacjilator.ts";
 
 /**

--- a/workflows/reacjilator.ts
+++ b/workflows/reacjilator.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { def as detectLang } from "../functions/detect_lang.ts";
 import { def as translate } from "../functions/translate.ts";
 


### PR DESCRIPTION
Updates deno-slack-sdk and deno-slack-api imports to use the new JSR packages (@slack/sdk and @slack/api).

Made with [Cursor](https://cursor.com)