### PR TITLE
Fix 403 by migrating DeepL auth from legacy body auth to header auth

### DIFF
--- a/functions/translate.ts
+++ b/functions/translate.ts
@@ -59,17 +59,17 @@ export default SlackFunction(def, async ({ inputs, client, env }) => {
   const translationTarget = translationTargetResponse.messages[0];
   const translationTargetThreadTs = translationTarget.thread_ts;
 
-  const authKey = env.DEEPL_AUTH_KEY;
+  const authKey = normalizeAuthKey(env.DEEPL_AUTH_KEY);
   if (!authKey) {
     const error =
       "DEEPL_AUTH_KEY needs to be set. You can place .env file for local dev. For production apps, please run `slack env add DEEPL_AUTH_KEY (your key here)` to set the value.";
     return { error };
   }
-  const apiSubdomain = authKey.endsWith(":fx") ? "api-free" : "api";
+  const apiSubdomain = authKey.toLowerCase().endsWith(":fx")
+    ? "api-free"
+    : "api";
   const url = `https://${apiSubdomain}.deepl.com/v2/translate`;
   const body = new URLSearchParams();
-
-  body.append("auth_key", authKey);
 
   const targetText = translationTarget.text
     // Before sending the text to the DeepL API,
@@ -130,14 +130,16 @@ export default SlackFunction(def, async ({ inputs, client, env }) => {
     method: "POST",
     headers: {
       "content-type": "application/x-www-form-urlencoded;charset=utf-8",
+      "Authorization": `DeepL-Auth-Key ${authKey}`,
     },
     body,
   });
   if (deeplResponse.status !== 200) {
     if (deeplResponse.status === 403) {
-      // If the status code is 403, the given auth key is not valid
+      // DeepL returns 403 for several auth-related causes (key, endpoint, auth method).
+      const body = await deeplResponse.text();
       const error =
-        `Translating a message failed! Please make sure if the DEEPL_AUTH_KEY is correct. - (status: ${deeplResponse.status}, target text: ${
+        `Translating a message failed! Please check DEEPL_AUTH_KEY and DeepL API auth settings. - (status: ${deeplResponse.status}, body: ${body}, target text: ${
           targetText.substring(0, 30)
         }...)`;
       console.log(error);
@@ -247,4 +249,17 @@ async function sayInThread(
     text,
     thread_ts: threadTs,
   });
+}
+
+function normalizeAuthKey(rawAuthKey: string | undefined): string | undefined {
+  if (!rawAuthKey) {
+    return undefined;
+  }
+  const trimmed = rawAuthKey.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  // A quoted value can be accidentally set by env tooling or copy/paste.
+  const unquoted = trimmed.replace(/^(['"])(.*)\1$/, "$2").trim();
+  return unquoted.length === 0 ? undefined : unquoted;
 }

--- a/functions/translate_test.ts
+++ b/functions/translate_test.ts
@@ -60,9 +60,13 @@ function stubFetch() {
             status: 200,
           });
         }
-        case "https://api.deepl.com/v2/translate": {
-          const body = await req.formData();
-          if (body.get("auth_key") === "valid") {
+        case "https://api.deepl.com/v2/translate":
+        case "https://api-free.deepl.com/v2/translate": {
+          const authorization = req.headers.get("Authorization");
+          if (
+            authorization === "DeepL-Auth-Key valid" ||
+            authorization === "DeepL-Auth-Key valid:fx"
+          ) {
             return new Response(
               JSON.stringify({
                 translations: [
@@ -78,7 +82,10 @@ function stubFetch() {
               },
             );
           }
-          return new Response("", { status: 403 });
+          return new Response(
+            JSON.stringify({ message: "Authorization failed" }),
+            { status: 403 },
+          );
         }
         default:
           throw Error(
@@ -134,6 +141,38 @@ Deno.test("Fail to translate with an invalid auth key", async () => {
   assertEquals(outputs, undefined);
   assertEquals(
     error,
-    "Translating a message failed! Please make sure if the DEEPL_AUTH_KEY is correct. - (status: 403, target text: Make work life simpler, more p...)",
+    'Translating a message failed! Please check DEEPL_AUTH_KEY and DeepL API auth settings. - (status: 403, body: {"message":"Authorization failed"}, target text: Make work life simpler, more p...)',
+  );
+});
+
+Deno.test("Translate with quoted DeepL free auth key", async () => {
+  using _stubFetch = stubFetch();
+  const inputs = {
+    channelId: "C123",
+    messageTs: "1670566778.964519",
+    lang: "ja",
+  };
+  const env = { DEEPL_AUTH_KEY: ' "valid:fx"  ', DEBUG_MODE: "false" };
+  const token = "valid";
+  const { outputs } = await handler(createContext({ inputs, env, token }));
+  assertEquals(outputs, { ts: "1111.2222" });
+});
+
+Deno.test("Fail when auth key is blank after trim", async () => {
+  using _stubFetch = stubFetch();
+  const inputs = {
+    channelId: "C123",
+    messageTs: "1670566778.964519",
+    lang: "ja",
+  };
+  const env = { DEEPL_AUTH_KEY: "   ", DEBUG_MODE: "false" };
+  const token = "valid";
+  const { outputs, error } = await handler(
+    createContext({ inputs, env, token }),
+  );
+  assertEquals(outputs, undefined);
+  assertEquals(
+    error,
+    "DEEPL_AUTH_KEY needs to be set. You can place .env file for local dev. For production apps, please run `slack env add DEEPL_AUTH_KEY (your key here)` to set the value.",
   );
 });


### PR DESCRIPTION
## 背景 / Background
- 翻訳処理で `403` が発生していた。 / Translation workflow was failing with `403`.

## 原因 / Cause
- 以前の実装は、DeepL に `auth_key` を **request body** で送る方式だった。 / The previous implementation sent DeepL `auth_key` in the **request body**.
- 現在の DeepL は、`Authorization: DeepL-Auth-Key <key>` の **header 認証方式** が前提。 / Current DeepL authentication expects **header-based auth** via `Authorization: DeepL-Auth-Key <key>`.
- 旧方式のままだと `403` になる。 / Keeping the legacy method results in `403`.

## 改善内容 / Improvements
- 認証方式を旧方式から新方式へ更新。 / Migrated auth from legacy body-based method to header-based method.
- `auth_key` の body 送信を廃止し、`Authorization` ヘッダへ移行。 / Removed body `auth_key` and moved authentication to `Authorization` header.
- `DEEPL_AUTH_KEY` の前後空白・引用符を除去してから使用するよう改善。 / Added normalization for `DEEPL_AUTH_KEY` (trim + quote stripping).
- Free/Pro のエンドポイント判定を安定化（`:fx` 判定）。 / Stabilized Free/Pro endpoint selection (`:fx` detection).
- 403時に DeepL の response body も出力して、次回の確認をしやすくした。 / Included DeepL response body in 403 errors for clearer follow-up.

## テスト / Testing
- `deno fmt functions/translate.ts functions/translate_test.ts`
- `deno test functions/translate_test.ts`
- `ok | 5 passed | 0 failed`
